### PR TITLE
Set Python path correctly when running as a WSGI service

### DIFF
--- a/cohpy/wsgi.py
+++ b/cohpy/wsgi.py
@@ -8,6 +8,10 @@ https://docs.djangoproject.com/en/1.8/howto/deployment/wsgi/
 """
 
 import os
+import sys
+from django.core.wsgi import get_wsgi_application
+
+sys.path.append(os.path.dirname(__file__))
 
 from django.core.wsgi import get_wsgi_application
 


### PR DESCRIPTION
This adds the directory wsgi.py resides in to the Python path to ensure that the WSGI service will run properly.