### PR TITLE
Fix for current meetups prematurely becoming past meetups

### DIFF
--- a/cohpy/config/settings/base.py
+++ b/cohpy/config/settings/base.py
@@ -108,7 +108,7 @@ WSGI_APPLICATION = 'wsgi.application'
 
 LANGUAGE_CODE = 'en-us'
 
-TIME_ZONE = 'UTC'
+TIME_ZONE = 'EST'
 
 USE_I18N = True
 

--- a/cohpy/meetups/views.py
+++ b/cohpy/meetups/views.py
@@ -1,13 +1,17 @@
 from django.shortcuts import render
 from django.utils import timezone
+from datetime import timedelta
 
 from .models import Meetup
 
 from info_blocks.views import latest_general_info, latest_dojo_info
 
+# Since meetups list a start time, this is the number of hours after the
+# start time to still display the meetup as a "current" and not past meetup.
+HOURS_SLACK=4
 
 def home_page(request):
-    upcoming_meetups = Meetup.objects.filter(meetup_type__name='monthly').filter(date__gte=timezone.now()).order_by('date')
+    upcoming_meetups = Meetup.objects.filter(meetup_type__name='monthly').filter(date__gte=timezone.now() - timedelta(hours=HOURS_SLACK)).order_by('date')
     last_meetup = Meetup.objects.filter(meetup_type__name='monthly').latest('date')
     return render(request, 'home.html', {
         'upcoming_meetups': upcoming_meetups,
@@ -17,7 +21,7 @@ def home_page(request):
     })
 
 def index(request):
-    meetups = Meetup.objects.filter(meetup_type__name='monthly').filter(date__lt=timezone.now()).order_by('-date')
+    meetups = Meetup.objects.filter(meetup_type__name='monthly').filter(date__lt=timezone.now() - timedelta(hours=HOURS_SLACK)).order_by('-date')
     return render(request, 'meetups/index.html', {
         'meetups': meetups,
     })


### PR DESCRIPTION
This will fix the issue of meetups dropping off the "current" list before they are done.

The change to make Django EST instead of UTC isn't required, but does make things consistent with the timezone the meetups actually occur in. Once this change is made, times in the database will have to be changed as they are currently being stored as UTC.

The view change adds a slack of 4 hours, since the list of current meetups uses the start time of the event to decide when it has passed, this adds 4 hours to "now" as slack. This means the server will continue to show the meetup is current for 4 hours after the start time of the meetup.